### PR TITLE
Remove thousands delimiter from the price

### DIFF
--- a/Bloomberg.pm
+++ b/Bloomberg.pm
@@ -1,5 +1,5 @@
 package Finance::Quote::Bloomberg;
-require 5.004;
+require 5.013002;
 
 use strict;
 
@@ -44,7 +44,7 @@ sub bloomberg {
 
     my $tree = HTML::TreeBuilder->new_from_content($reply->content);
     my @price_array = $tree -> look_down(_tag=>'div',class=>'price');
-    my $price = @price_array[0]->as_text;
+    my $price = @price_array[0]->as_text =~ s/,//r;
     my @curr_array = $tree -> look_down(_tag=>'div',class=>'currency');
     my $curr = @curr_array[0]->as_text;
     my @date_array = $tree -> look_down(_tag=>'div',class=>'price-datetime');


### PR DESCRIPTION
Hello,
you have a great repo with useful and awesome bloomberg quote. I have tried your file to get quotes from bloomberg into the GnuCash. It works great, but I got an error when trying to obtain quotes with higher value than $1,000.00 (e.g XAUUSD:CUR for gold spot). Then GnuCash complained about "System error." I went on and investigated and found out it complains about comma in the price. I went ahead and removed it in the code and now it works. I'm not very well acquainted with Perl, so I did some search on Google and fixed it as best as I could.

Thanks for your work!

Tomas
