### PR TITLE
Handle an error due to some quote pages of bloomberg were changed

### DIFF
--- a/Bloomberg.pm
+++ b/Bloomberg.pm
@@ -47,8 +47,6 @@ sub bloomberg {
     my $price = @price_array[0]->as_text =~ s/,//r;
     my @curr_array = $tree -> look_down(_tag=>'div',class=>'currency');
     my $curr = @curr_array[0]->as_text;
-    my @date_array = $tree -> look_down(_tag=>'div',class=>'price-datetime');
-    my $date = @date_array[0]->as_text;
     #print $price;
     #print $name;
 

--- a/Bloomberg.pm
+++ b/Bloomberg.pm
@@ -43,10 +43,10 @@ sub bloomberg {
     }
 
     my $tree = HTML::TreeBuilder->new_from_content($reply->content);
-    my @price_array = $tree -> look_down(_tag=>'div',class=>'price');
-    my $price = @price_array[0]->as_text =~ s/,//r;
-    my @curr_array = $tree -> look_down(_tag=>'div',class=>'currency');
-    my $curr = @curr_array[0]->as_text;
+    my @price_array = $tree -> look_down(_tag=>'meta','itemprop'=>'price');
+    my $price = @price_array[0]->attr('content');
+    my @curr_array = $tree -> look_down(_tag=>'meta','itemprop'=>'priceCurrency');
+    my $curr = @curr_array[0]->attr('content');
     #print $price;
     #print $name;
 


### PR DESCRIPTION
Hello,

I am a heavy user of Bloomberg.pm via the GnuCash.
Since I got an error "System error" from last week, I identified the cause.

In my research, the cause is that some quote pages of bloomberg were changed.

For example, since the VS:US(https://www.bloomberg.com/quote/VZ:US)
page doesn't have the tag(`<div class="price">, <div class="currency">`),
this script can't get the stock price and currency.

So that, these patches changes the tags to get the stock information.

Thanks, mikecaat