### PR TITLE
Obtain actual quotation date

### DIFF
--- a/Bloomberg.pm
+++ b/Bloomberg.pm
@@ -47,6 +47,8 @@ sub bloomberg {
     my $price = @price_array[0]->attr('content');
     my @curr_array = $tree -> look_down(_tag=>'meta','itemprop'=>'priceCurrency');
     my $curr = @curr_array[0]->attr('content');
+    my @date_array = $tree -> look_down(_tag=>'meta','itemprop'=>'quoteTime');
+    my $date = @date_array[0]->attr('content');
     #print $price;
     #print $name;
 
@@ -56,13 +58,12 @@ sub bloomberg {
     $funds{$name, 'currency'} = $curr;
     $funds{$name, 'success'}  = 1;
     $funds{$name, 'symbol'}  = $name;
+    $quoter->store_date(\%funds, $name, {isodate => substr($date,0,10)});
     $funds{$name, 'source'}   = 'Finance::Quote::Bloomberg';
     $funds{$name, 'name'}   = $name;
     $funds{$name, 'p_change'} = "";  # p_change is not retrieved (yet?)
     }
 
-    #will default to today
-    $quoter->store_date(\%funds, $name);
 
     # Check for undefined symbols
     foreach my $symbol (@symbols) {


### PR DESCRIPTION
Hi Alex,

First of all, thanks for sharing the script for the benefit of many GnuCash users.

Now, I updated the script so that it takes the quote date from the web page as well, instead of defaulting to today. I find this useful in two scenarios:

 - When I update the quotes during a workable day but NAV is still reflecting yesterday's valuation. 
 - When I update quotes during the weekend, so that I don't get duplicate prices when there's no new quotation.

Kind regards,
Pablo.